### PR TITLE
More detailed instructions for local install

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -81,42 +81,38 @@
         </div><!-- /.navbar -->
       </div>
 
-	<h3>Dowloadable IDE App</h3>
+      <h3>Dowloadable IDE App</h3>
 
       <div>
 	You can download the experimental Electron app:
 	<ul>
-	  <li><a href
-      ="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/NewspeakIDE.app.zip"
-      download> For MacOS (Catalina/Big Sur Intel/ARM)</a></li>
-	 <li> <a href =
-      "https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/newspeakIDE.zip"
-      download> For Windows 10 </a></li></ul>	  
-    </div>
+	  <li><a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/NewspeakIDE.app.zip" download> For MacOS (Catalina/Big Sur Intel/ARM)</a></li>
+	  <li><a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/newspeakIDE.zip" download> For Windows 10 </a></li></ul>
+      </div>
 
-    Or download the IDE as a locally servable Web app:
-<a href
-      ="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/servable.zip"
-      download>For all platforms</a>. Unzip the downloaded directory
-    and serve it; the script serve.sh in the directory will try and use a Python server.
-    
-    <h3>Licensing</h3>
+      Or download the IDE as a locally servable Web app:
+      <a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/servable.zip" download>For all platforms</a>.
+      <ol>
+	<li>Unzip the downloaded directory</li>
+	<li>Make <code>serve.sh</code> executable and run it.</li>
+	<li><a href="http://localhost:8080/primordialsoup.html?snapshot=HopscotchWebIDE.vfuel">Browse</a> to your local Newspeak instance.</li>
+      </ol>
+      <h3>Licensing</h3>
 
-    See <a href="license.html">license</a>. 
+      See <a href="license.html">license</a>.
 
-    <h3>Legacy Squeak Smalltalk Version</h3>
+      <h3>Legacy Squeak Smalltalk Version</h3>
       <div>
         <p>To run the Newspeak Smalltalk-based IDE, download an image and virtual
-        machine for your operating system and open the image with the
-	virtual machine.
-       
+          machine for your operating system and open the image with the
+	  virtual machine.
 	</p>
 
         <h4>Image</h4>
         <ul>
           <li><a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/newspeak-images/Newspeak%20Boot%20Image%202020-03-02%20(32%20bit).zip">2020-03-02
-	  (32-bit)</a></li>
-         <li><a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/newspeak-images/Newspeak%20Boot%20Image%202020-03-02%20(64%20bit).zip">2020-03-02 (64-bit)</a></li>	  
+	    (32-bit)</a></li>
+          <li><a href="https://github.com/newspeaklanguage/newspeaklanguage.github.io/raw/master/newspeak-images/Newspeak%20Boot%20Image%202020-03-02%20(64%20bit).zip">2020-03-02 (64-bit)</a></li>	  
         </ul>
 
         <h4>Virtual Machine</h4>


### PR DESCRIPTION
Documentation that makes explicit the steps to follow when installing a local instance of Newspeak.

- The script `serve.sh` may lack executable attributes after unzipping  (heads up to the user)
- When running the script, only the port on which the server is running is printed at the console, so the user may not guess that he needs to point his browser to `http://localhost:8080/primordialsoup.html?snapshot=HopscotchWebIDE.vfuel`.

Note: In addition to the text, some white space has been shuffled around (for example, `href` links that were spanning on two lines).

Thank you.
